### PR TITLE
Remove preceding comment

### DIFF
--- a/fnmatch.go
+++ b/fnmatch.go
@@ -1,6 +1,6 @@
+// Provide string-matching based on fnmatch.3
 package fnmatch
 
-// Provide string-matching based on fnmatch.3
 // There are a few issues that I believe to be bugs, but this implementation is
 // based as closely as possible on BSD fnmatch. These bugs are present in the
 // source of BSD fnmatch, and so are replicated here. The issues are as follows:

--- a/fnmatch.go
+++ b/fnmatch.go
@@ -1,6 +1,6 @@
-// Provide string-matching based on fnmatch.3
 package fnmatch
 
+// Provide string-matching based on fnmatch.3
 // There are a few issues that I believe to be bugs, but this implementation is
 // based as closely as possible on BSD fnmatch. These bugs are present in the
 // source of BSD fnmatch, and so are replicated here. The issues are as follows:

--- a/fnmatch_test.go
+++ b/fnmatch_test.go
@@ -3,7 +3,7 @@ package fnmatch_test
 import (
 	"testing"
 
-	"github.com/danwakefield/fnmatch"
+	"github.com/gandarez/fnmatch"
 )
 
 // This is a set of tests ported from a set of tests for C fnmatch


### PR DESCRIPTION
Comments left before `package` declaration breaks `go mod vendor` in some operation systems. I've tested in a Raspberry Pi (which is an ARM v8).

```
internal error: failed to find embedded files of github.com/danwakefield/fnmatch: /home/pi/Development/go/pkg/mod/github.com/danwakefield/fnmatch@v0.0.0-20160403171240-cbb64ac3d964/fnmatch.go:1:1: expected 'package', found 'EOF'

```