### PR TITLE
Updated README.md to correct originator's name and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # fnmatch
-Updated clone of kballards golang fnmatch gist (https://gist.github.com/kballard/272720)
+Updated clone of lilyballs golang fnmatch gist (https://gist.github.com/lilyball/272720)
 
 


### PR DESCRIPTION
Just fixes the name of the fnmatch author and the link to the gist.